### PR TITLE
ensure compiler generates bytecode that runs on Java 8, even if we build using Java 11

### DIFF
--- a/java-parent-pom/pom.xml
+++ b/java-parent-pom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>root-parent-pom</artifactId>
-        <version>1.2.8</version>
+        <version>1.2.9-SNAPSHOT</version>
         <relativePath />
     </parent>
 

--- a/root-parent-pom/pom.xml
+++ b/root-parent-pom/pom.xml
@@ -365,6 +365,8 @@
             <properties>
                 <!-- https://github.com/osundblad/intellij-annotations-instrumenter-maven-plugin/issues/29 -->
                 <se.eris.notnull.instrument>false</se.eris.notnull.instrument>
+                <!-- see https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/ -->
+                <maven.compiler.release>8</maven.compiler.release>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
Issue #57 