### PR TITLE
Pass ${argLine} through when overriding argLine for Java 11/17

### DIFF
--- a/root-parent-pom/pom.xml
+++ b/root-parent-pom/pom.xml
@@ -17,7 +17,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.openhft</groupId>
@@ -65,6 +66,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!--
+            By default (on Java 8) ${jvm.requiredArgs} is an empty string, on other javas it will
+            contain the arguments necessary to run the Chronicle libraries
+        -->
+        <jvm.requiredArgs/>
     </properties>
 
     <build>
@@ -113,13 +119,10 @@
                     <version>2.8.2</version>
                 </plugin>
 
-                <!--
-                    Do not upgrade to M5, it's broken https://issues.apache.org/jira/browse/SUREFIRE-1863
-                -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M4</version>
+                    <version>3.0.0-M6</version>
                 </plugin>
 
                 <plugin>
@@ -308,6 +311,19 @@
                 </executions>
             </plugin>
 
+            <!--
+                Set argLine to include ${jvm.requiredArgs} (JVM args needed to run Chronicle libraries on the detected JVM)
+
+                If a child POM wants to override the argLine, they must include ${jvm.requiredArgs}
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} ${jvm.requiredArgs}</argLine>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 
@@ -380,42 +396,48 @@
             <activation>
                 <jdk>[11,16]</jdk>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>--add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports
-                                java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- Required JVM args for Java 11 -> 16 -->
+                <jvm.requiredArgs>
+                    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                    --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+                    --add-exports java.base/sun.nio.ch=ALL-UNNAMED
+                </jvm.requiredArgs>
+            </properties>
         </profile>
         <profile>
             <id>java17</id>
             <activation>
                 <jdk>[17,</jdk>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>
-                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-                                --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
-                                --add-opens=jdk.compiler/com.sun.tools.javac=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
-                                --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
-                                --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <!-- Required JVM args for Java 17+ -->
+                <jvm.requiredArgs>
+                    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
+                    --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+                    --add-opens=jdk.compiler/com.sun.tools.javac=ALL-UNNAMED
+                    --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                    --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED
+                </jvm.requiredArgs>
+            </properties>
+        </profile>
+        <!--
+            Only default argLine if it's not set. If we blanket default it, it can't be overriden!?
+        -->
+        <profile>
+            <id>default-argLine</id>
+            <activation>
+                <property>
+                    <name>!argLine</name>
+                </property>
+            </activation>
+            <properties>
+                <argLine/>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
We now have builds that only build in Java 11. So my first approach to the JaCoCo maven plugin argLine issue (just build in Java 8 and don't solve it) won't fly anymore.

This seems to work. There is lots written about this issue (e.g. http://www.devll.org/blog/2020/java/jacoco-argline.html)

EDIT:

I changed the approach here. Looking at how argLine is used in our projects, we probably need the ability to add to it while getting the java 8/11/17 flags from the parent POM. The easiest way to achieve this looks like to declare a variable `jvm.argLine` which child POMs can include in their argLines (e.g. `<argLine>${jvm.argLine} -XX:-CompactStrings</argLine>`)