### PR TITLE
Throw iae on missing class alias 23

### DIFF
--- a/chronicle-bom/pom.xml
+++ b/chronicle-bom/pom.xml
@@ -35,7 +35,7 @@
         <chronicle.network.version>2.23.32</chronicle.network.version>
         <chronicle.queue.version>5.23.47</chronicle.queue.version>
         <chronicle.zero.version>2.23.6</chronicle.zero.version>
-        <chronicle.wire.enterprise.version>2.23.3</chronicle.wire.enterprise.version>
+        <chronicle.wire.enterprise.version>2.23.4-SNAPSHOT</chronicle.wire.enterprise.version>
         <chronicle.queue.enterprise.version>2.23.37</chronicle.queue.enterprise.version>
         <chronicle.map.enterprise.version>2.23.6</chronicle.map.enterprise.version>
         <chronicle.datagrid.version>2.23.21</chronicle.datagrid.version>


### PR DESCRIPTION
Bumped Chronicle Wire version to pick up functionality allowing IAE to be propagated on a missing class alias.