### PR TITLE
Bump test framework

### DIFF
--- a/chronicle-bom/pom.xml
+++ b/chronicle-bom/pom.xml
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-test-framework</artifactId>
-                <version>2.25ea1</version>
+                <version>2.25ea2-SNAPSHOT</version>
             </dependency>
 
 


### PR DESCRIPTION
Prep for release of test framework to integrate ephemeral `TcpProxy` constructor into network.

https://github.com/OpenHFT/Chronicle-Test-Framework/pull/45