### PR TITLE
Disable @NotNull instrumentation

### DIFF
--- a/root-parent-pom/pom.xml
+++ b/root-parent-pom/pom.xml
@@ -432,7 +432,7 @@
         <profile>
             <id>notnull-instrumenter</id>
             <activation>
-                <jdk>[,17]</jdk>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <build>
                 <plugins>


### PR DESCRIPTION
A prev commit enabled @NotNull instrumentation by default. Unfortunately this instrumentation generates IllegalArgumentExceptions at @NotNull call sites when they are null and not NullPointerExceptions. This breaks a number of downstream tests and methods where we expect NPEs to be thrown. We will disable this for now, but it needs to be revisited.

Please see this issue for more info: https://github.com/osundblad/intellij-annotations-instrumenter-maven-plugin/issues/53