### PR TITLE
Remove old check.thread.safety property

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,5 +1,4 @@
 # Tracing if resources are closed/released correctly.
 jvm.resource.tracing=true
-check.thread.safety=true
 # for profiling
 jvm.safepoint.enabled=false


### PR DESCRIPTION
The check.thread.saftety property has not been used for a while. Removing references to it.