### PR TITLE
Bump SLF4J to 2.0.17 in third-party BOM

### DIFF
--- a/third-party-bom/pom.xml
+++ b/third-party-bom/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty.version>9.4.46.v20220331</jetty.version>
         <log4j2.version>2.17.2</log4j2.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.16</slf4j.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <junit.platform.provider.version>1.10.0</junit.platform.provider.version>
         <jmh.version>1.36</jmh.version>

--- a/third-party-bom/pom.xml
+++ b/third-party-bom/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jetty.version>9.4.46.v20220331</jetty.version>
         <log4j2.version>2.17.2</log4j2.version>
-        <slf4j.version>2.0.16</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <junit.jupiter.version>5.10.0</junit.jupiter.version>
         <junit.platform.provider.version>1.10.0</junit.platform.provider.version>
         <jmh.version>1.36</jmh.version>


### PR DESCRIPTION
Upgrades the SLF4J property in the third-party BOM from **1.7.36 → 2.0.17**:

```diff
- <slf4j.version>1.7.36</slf4j.version>
+ <slf4j.version>2.0.17</slf4j.version>
```

## Why this change?

* **Active line / maintenance**: 2.x is the actively maintained series.
* **JDK compatibility**: Improved support for newer JDKs (incl. 17/21).
* **Bug fixes & performance**: Pulls in numerous fixes and small improvements since 1.7.x.
* **API improvements**: Access to the modern SLF4J 2.x event API and features.

## Impact & considerations

* **Downstream impact**: Projects inheriting this BOM will align to `slf4j-api:2.0.17`.
* **Bindings/bridges**:

  * If you use Log4j2, prefer **`log4j-slf4j2-impl`** (not the old `log4j-slf4j-impl`).
  * If you use Logback, ensure **Logback 1.4.x+** which supports SLF4J 2.x.
  * Remove legacy bridges that target 1.7 behavior if present.
* **Potential breaking changes**:

  * Some 1.7-era binding artifacts are not compatible with 2.x.
  * MDC APIs and the new event builder exist in 2.x; verify any direct SLF4J API usage if you relied on edge behaviors.
