### PR TITLE
Use maven-source-plugin jar-no-fork for attach-sources

### DIFF
--- a/java-parent-pom/pom.xml
+++ b/java-parent-pom/pom.xml
@@ -120,7 +120,7 @@
                     <execution>
                         <id>attach-sources</id>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
Without this change the checkstyle plugin is run twice in every build