### PR TITLE
CORE-65: Bump Wire snapshot in Chronicle BOM

### DIFF
--- a/chronicle-bom/pom.xml
+++ b/chronicle-bom/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-wire</artifactId>
-                <version>2026.5</version>
+                <version>2026.6-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Context

Part of CORE-65: make finite float/double values round-trip faithfully through Chronicle's text wires. The bug split across two layers: the writer (small-double formatting in `YamlWireOut`) and the reader (`Maths.asDouble` not correctly rounded on common decimal inputs).

Stacked PRs:
1. `OpenHFT/Chronicle-Core` — `Maths.asDouble` Clinger fast path, regression tests, and accuracy docs.
2. `OpenHFT/OpenHFT` / `chronicle-bom` — point consumers at snapshots carrying the CORE-65 stack.
3. `OpenHFT/Chronicle-Bytes` — `parseDouble` precision regression suite and accuracy docs.
4. `OpenHFT/Chronicle-Wire` — write all finite doubles/floats as faithful JSON numbers and cover formatter thresholds.

Merge/deploy order: Core first, then BOM, then Bytes and Wire. Consumer CI will only see the parser fix after the Core snapshot/release is available through the BOM.

## What Changed

`chronicle-bom` now points `chronicle-wire` at `2026.6-SNAPSHOT`, the next snapshot for the Wire side of CORE-65.

Develop already contains the related Core/Bytes snapshot alignment:

- `chronicle.core.version` -> `2026.4-SNAPSHOT`
- `chronicle-bytes` -> `2026.4-SNAPSHOT`

This PR completes the BOM side of the stack so downstream libraries can resolve the Wire snapshot that contains the faithful finite-number writer changes.

## Why

Without this BOM update, downstream consumers importing `chronicle-bom:2026.0-SNAPSHOT` can pick up the Core/Bytes snapshots but still resolve `chronicle-wire` to the old released `2026.5`, missing the JSON/YAML finite-number formatting fix.

No dependency graph shape changes are intended beyond the version string.

## Reviewer Notes

This PR is intentionally small. It should be merged/deployed after the Core fix is available and before downstream Bytes/Wire consumers expect the complete CORE-65 stack from the BOM.

## Verification

- `mvn -q -pl chronicle-bom validate`