### PR TITLE
Add security vulnerability disclosure policy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,12 @@ CM is designed to store the data off-heap, which means it minimizes the heap usa
 CM is structured key-value store able to support exceptionally high updates and high throughput data e.g. OPRA Market Data with minimum configuration.
 Replication is provided by Chronicle Map Enterprise
 
+== Reporting security issues
+
+If you discover a security vulnerability in any Chronicle / OpenHFT library, please report it responsibly by emailing security@chronicle.software.
+Please do not open a public GitHub issue or pull request for security vulnerabilities.
+See <<SECURITY.md#,our Security Policy>> for details on what to include and what to expect.
+
 == Contributor agreement
 
 For us to accept contributions to open source libraries we require contributors to sign the below

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Chronicle Software takes the security of our software seriously. If you believe
+you have found a security vulnerability in any Chronicle / OpenHFT library, we
+encourage you to report it to us responsibly.
+
+**Please do not report security vulnerabilities through public GitHub issues,
+pull requests, or discussions.**
+
+Instead, please email full details to:
+
+**security@chronicle.software**
+
+To help us triage and resolve the issue quickly, please include where possible:
+
+* The product/library and version affected (e.g. Chronicle Queue 5.x).
+* A description of the vulnerability and its potential impact.
+* Steps to reproduce, including any proof-of-concept code or configuration.
+* Any known mitigations or workarounds.
+
+## What to Expect
+
+* We will acknowledge receipt of your report as soon as possible.
+* We will investigate and keep you informed of our progress.
+* We ask that you give us a reasonable period of time to investigate and
+  remediate an issue before any public disclosure, so that users can be
+  protected.
+
+We appreciate your efforts to disclose your findings responsibly and will make
+every effort to acknowledge your contribution.


### PR DESCRIPTION
Add SECURITY.md directing disclosures to security@chronicle.software (GitHub auto-detects this file for the Security Policy tab and "Report a vulnerability" link) and link it from the README.