### PR TITLE
QUEUE-143: Manage Apache Commons Compress in third-party BOM

### DIFF
--- a/third-party-bom/pom.xml
+++ b/third-party-bom/pom.xml
@@ -37,7 +37,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <commons-codec.version>1.19.0</commons-codec.version>
         <commons-compress.version>1.28.0</commons-compress.version>
+        <commons-io.version>2.20.0</commons-io.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
         <jetty.version>9.4.46.v20220331</jetty.version>
         <log4j2.version>2.17.2</log4j2.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -444,6 +447,18 @@
             </dependency>
 
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
@@ -452,7 +467,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.12.0</version>
+                <version>${commons-lang3.version}</version>
             </dependency>
 
             <dependency>
@@ -636,6 +651,39 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <version>3.9.1</version>
+                <configuration>
+                    <projectsDirectory>${project.basedir}/src/it</projectsDirectory>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <localRepositoryPath>${project.build.directory}/it-repository</localRepositoryPath>
+                    <goals>
+                        <goal>verify</goal>
+                    </goals>
+                    <properties>
+                        <third-party-bom.version>${project.version}</third-party-bom.version>
+                    </properties>
+                    <streamLogs>true</streamLogs>
+                    <failIfNoProjects>true</failIfNoProjects>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>verify-commons-compress-consumer</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <url>https://chronicle.software</url>
 

--- a/third-party-bom/pom.xml
+++ b/third-party-bom/pom.xml
@@ -37,6 +37,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <commons-compress.version>1.28.0</commons-compress.version>
         <jetty.version>9.4.46.v20220331</jetty.version>
         <log4j2.version>2.17.2</log4j2.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -440,6 +441,12 @@
                 <artifactId>guava-testlib</artifactId>
                 <scope>test</scope>
                 <version>33.1.0-jre</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
             </dependency>
 
             <dependency>

--- a/third-party-bom/src/it/commons-compress-consumer/pom.xml
+++ b/third-party-bom/src/it/commons-compress-consumer/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.openhft.bom.it</groupId>
+    <artifactId>commons-compress-consumer</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <third-party-bom.version>missing</third-party-bom.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>net.openhft</groupId>
+                <artifactId>third-party-bom</artifactId>
+                <version>${third-party-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>8</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.1</version>
+                <executions>
+                    <execution>
+                        <id>run-tar-smoke-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>net.openhft.bom.it.CommonsCompressSmokeTest</mainClass>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/third-party-bom/src/it/commons-compress-consumer/src/main/java/net/openhft/bom/it/CommonsCompressSmokeTest.java
+++ b/third-party-bom/src/it/commons-compress-consumer/src/main/java/net/openhft/bom/it/CommonsCompressSmokeTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ */
+package net.openhft.bom.it;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemProperties;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public final class CommonsCompressSmokeTest {
+    private CommonsCompressSmokeTest() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        assertArtifactVersion(TarArchiveEntry.class, "commons-compress", "1.28.0");
+        assertArtifactVersion(SystemProperties.class, "commons-lang3", "3.18.0");
+        assertArtifactVersion(IOUtils.class, "commons-io", "2.20.0");
+        assertArtifactVersion(Hex.class, "commons-codec", "1.19.0");
+
+        byte[] payload = "BOM dependency compatibility".getBytes(StandardCharsets.UTF_8);
+        ByteArrayOutputStream archiveBytes = new ByteArrayOutputStream();
+        try (TarArchiveOutputStream output = new TarArchiveOutputStream(archiveBytes)) {
+            TarArchiveEntry entry = new TarArchiveEntry("entry.txt");
+            entry.setSize(payload.length);
+            output.putArchiveEntry(entry);
+            output.write(payload);
+            output.closeArchiveEntry();
+        }
+
+        try (TarArchiveInputStream input = new TarArchiveInputStream(
+                new ByteArrayInputStream(archiveBytes.toByteArray()))) {
+            TarArchiveEntry entry = input.getNextTarEntry();
+            if (entry == null || !"entry.txt".equals(entry.getName()))
+                throw new AssertionError("tar entry was not preserved");
+            ByteArrayOutputStream restored = new ByteArrayOutputStream();
+            byte[] buffer = new byte[128];
+            int read;
+            while ((read = input.read(buffer)) >= 0)
+                restored.write(buffer, 0, read);
+            if (!Arrays.equals(payload, restored.toByteArray()))
+                throw new AssertionError("tar payload was not preserved");
+        }
+    }
+
+    private static void assertArtifactVersion(Class<?> type, String artifactId, String version) {
+        URL location = type.getProtectionDomain().getCodeSource().getLocation();
+        String expectedJar = artifactId + "-" + version + ".jar";
+        if (!location.getPath().endsWith(expectedJar))
+            throw new AssertionError(type.getName() + " loaded from " + location +
+                    ", expected " + expectedJar);
+    }
+}


### PR DESCRIPTION
## Refresh on 12 September 2026

Merged develop `12dfdf30cfc52687f1c59df886aaf5c3dc6c6877` into the existing branch with normal forward commits. Updated head: `50bf937de7b250c8408c8b26ebb96db44a2fbcbe`. Both develop `12dfdf30cfc52687f1c59df886aaf5c3dc6c6877` and the declared parent are ancestors of this head; both missing-commit counts are zero.

Retained current BOM changes. The real Commons Compress archive consumer and Maven Invoker smoke passed on Java 8 and 21 (one successful integration build each).

Keep dependency management separate from the broad quality-policy proposal.

Local runs used Linux x86-64 and OpenJDK 21.0.12 unless Java 8 is explicitly stated (8u502). Reported test counts include skips. Commands requested zero Surefire reruns. Draft status and declared target are retained.

Earlier implementation/review notes follow. Earlier validation and performance claims apply only to their stated revisions and are superseded by the current receipt above where they differ.

---

QUEUE-143: Manage the Commons family used by Compress 1.28.0: Compress 1.28.0, Codec 1.19.0, IO 2.20.0 and Lang 3.18.0. This aligns the four managed versions before CQE introduces its optional compression dependency. Dependency management can change existing/transitive versions but does not add Compress to every consumer.

The ordinary Maven lifecycle runs a real Invoker consumer that depends on Compress through the BOM and performs a TAR round trip. This includes consumer-test execution, so the PR is broader than coordinate-only work.

### Validation

At `fe45ecd9d385005df4e923b19ac5b1f0c5db4baf`, 11 September 2026, Linux/Maven 3.9.11:

- `mvn -B -nsu -f third-party-bom/pom.xml verify -Dsurefire.rerunFailingTestsCount=0` passed on actual Java 8u502 and Java 21.0.12. Each Invoker run executed one consumer successfully with zero failed or skipped projects.
- Ran the packaged consumer JAR directly with its resolved dependency classpath on both JDKs; both passed. Recorded SHA-256 values for the consumer and all resolved dependency JARs. JAR-name assertions alone are not treated as provenance.
- The four versions match Apache's [published Compress 1.28.0 dependency family](https://commons.apache.org/proper/commons-compress/dependencies.html).

Keep draft pending qualification of the actual packaged Chronicle consumer and intended platforms. These small consumer runs do not establish application-level exposure to an advisory, complete runtime compatibility or a blanket security guarantee.
