### PR TITLE
QUEUE-143/144/146: stage coordinated 2026.10 snapshots

### DIFF
--- a/chronicle-bom/pom.xml
+++ b/chronicle-bom/pom.xml
@@ -33,9 +33,13 @@
     </description>
     <properties>
         <chronicle.network.version>2026.3</chronicle.network.version>
+        <!-- //! Queue #1739-#1746 form one coordinated landing chain and use this distinct
+             snapshot so downstream CQE builds cannot silently resolve the previous Queue API. -->
         <chronicle.queue.version>2026.10-SNAPSHOT</chronicle.queue.version>
         <chronicle.zero.version>2026.1</chronicle.zero.version>
         <chronicle.wire.enterprise.version>2026.1</chronicle.wire.enterprise.version>
+        <!-- //! CQE #956-#960 compile and test against the coordinated Queue chain above;
+             sharing its visible snapshot generation prevents mixed pre-QUEUE-146 artifacts. -->
         <chronicle.queue.enterprise.version>2026.10-SNAPSHOT</chronicle.queue.enterprise.version>
         <chronicle.ring.version>2026.2</chronicle.ring.version>
         <chronicle.fix.version>2026.14</chronicle.fix.version>
@@ -107,6 +111,8 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-wire</artifactId>
+                <!-- //! Wire #1280 supplies the context-count and EOF contracts consumed by
+                     Queue #1746 and CSE #842, so staged consumers must not fall back to 2026.8. -->
                 <version>2026.10-SNAPSHOT</version>
             </dependency>
 

--- a/chronicle-bom/pom.xml
+++ b/chronicle-bom/pom.xml
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-wire</artifactId>
-                <version>2026.8-SNAPSHOT</version>
+                <version>2026.10-SNAPSHOT</version>
             </dependency>
 
             <dependency>

--- a/chronicle-bom/pom.xml
+++ b/chronicle-bom/pom.xml
@@ -32,11 +32,19 @@
         chronicle dependencyManagement section.
     </description>
     <properties>
+        <!-- //! This staged BOM retains the shared 2026.0-SNAPSHOT coordinate. Prevent ordinary
+             remote deployment; qualify it with install in an isolated Maven repository until
+             the coordinated CI publication repository is explicitly configured. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
         <chronicle.network.version>2026.3</chronicle.network.version>
-        <chronicle.queue.version>2026.6</chronicle.queue.version>
+        <!-- //! Queue #1739-#1746 form one coordinated landing chain and use this distinct
+             snapshot so downstream CQE builds cannot silently resolve the previous Queue API. -->
+        <chronicle.queue.version>2026.10-SNAPSHOT</chronicle.queue.version>
         <chronicle.zero.version>2026.1</chronicle.zero.version>
         <chronicle.wire.enterprise.version>2026.1</chronicle.wire.enterprise.version>
-        <chronicle.queue.enterprise.version>2026.5</chronicle.queue.enterprise.version>
+        <!-- //! CQE #956-#960 compile and test against the coordinated Queue chain above;
+             sharing its visible snapshot generation prevents mixed pre-QUEUE-146 artifacts. -->
+        <chronicle.queue.enterprise.version>2026.10-SNAPSHOT</chronicle.queue.enterprise.version>
         <chronicle.ring.version>2026.2</chronicle.ring.version>
         <chronicle.fix.version>2026.14</chronicle.fix.version>
         <chronicle.services.version>2026.7</chronicle.services.version>

--- a/chronicle-bom/pom.xml
+++ b/chronicle-bom/pom.xml
@@ -33,10 +33,10 @@
     </description>
     <properties>
         <chronicle.network.version>2026.3</chronicle.network.version>
-        <chronicle.queue.version>2026.6</chronicle.queue.version>
+        <chronicle.queue.version>2026.10-SNAPSHOT</chronicle.queue.version>
         <chronicle.zero.version>2026.1</chronicle.zero.version>
         <chronicle.wire.enterprise.version>2026.1</chronicle.wire.enterprise.version>
-        <chronicle.queue.enterprise.version>2026.5</chronicle.queue.enterprise.version>
+        <chronicle.queue.enterprise.version>2026.10-SNAPSHOT</chronicle.queue.enterprise.version>
         <chronicle.ring.version>2026.2</chronicle.ring.version>
         <chronicle.fix.version>2026.14</chronicle.fix.version>
         <chronicle.services.version>2026.7</chronicle.services.version>
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>net.openhft</groupId>
                 <artifactId>chronicle-wire</artifactId>
-                <version>2026.8</version>
+                <version>2026.10-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Align managed Queue/CQE coordinates on `2026.10-SNAPSHOT`. Wire staging is already inherited from live develop, so this PR must not count that change again. Its live incremental comparison has four commits. BOM deploy-skip protection is not proof that every downstream publication is isolated.

Keep this coordinate-only PR draft. Promotion needs one receipt binding the exact Wire, Queue and CQE sources to effective Maven models, resolved classpaths, co-built Queue main/test JARs, CQE compilation/tests and packaging. Equal snapshot names or equal main/test-JAR versions do not establish identical source or a co-build. Packaging with tests skipped does not qualify tests.

The semantic prerequisite order is merged Wire #1280, Queue #1739/#1740/#1741, Queue #1745/#1746, and CQE #956/#957, with a refreshed #960 where required. The `DelegatingAppender.contextCount()` production repair belongs in CQE #956. Do not move it into this coordinate change.

The 9 September failure below concerns the recorded older dependency composition. It is not a demonstrated compiler failure for today's feature heads, and it does not classify TeamCity failures. Later targeted feature receipts are also not a replacement for a passing full CQE run: the preceding full run recorded 1,160 executions, two failures, one error and 122 skips; its second complete acceptor-mode run did not execute. No new full composition qualification or remote publication was performed in this follow-up.

<details>
<summary>Historical 9 September staging receipt (older composition)</summary>

Align Queue's ordinary/test JARs and CQE on `2026.10-SNAPSHOT` for the coordinated staging build. Refresh the branch against develop `12dfdf30cfc52687f1c59df886aaf5c3dc6c6877`, preserving the previous staging history. Wire is already `2026.10-SNAPSHOT` on that base, so no Wire-version hunk remains.

The BOM itself still has the shared `2026.0-SNAPSHOT` coordinate. Set `maven.deploy.skip=true` to prevent ordinary remote deployment of this staged BOM. The validated publication boundary is local `install` into an isolated Maven repository. No shared snapshot repository, TeamCity publication configuration or remote deployment was changed or qualified; configure an isolated publication repository explicitly before any intentional deploy override.

Keep draft with [Queue #1750](https://github.com/OpenHFT/Chronicle-Queue/pull/1750) and [CQE #963](https://github.com/ChronicleEnterprise/Chronicle-Queue-Enterprise/pull/963).

Local validation on 9 September 2026, Linux/OpenJDK 21/Maven 3.9.11:

- Offline BOM `install` into an isolated repository passed, including Checkstyle. Installed POM SHA-256: `d35ed429e0edcbcf771426f8a3220674223ed6aba3472b9b789ce9e7c16efc34`.
- Queue's effective dependencies are identical before and after removing its direct Wire override: Wire resolves to `2026.10-SNAPSHOT` through this installed BOM.
- Queue compiles, packages and installs its runtime/test JARs successfully with tests skipped; binary compatibility passed.
- CQE resolves the matching Queue runtime/test JARs, but its compile fails: `DelegatingAppender`, `AsyncBufferedAppender` and `BufferedAppender` inherit conflicting `contextCount()` defaults from Wire's `MarshallableOut` and `DocumentContext`. This staged source/dependency composition is not qualified.
- Resolved Wire JAR SHA-256: `49fd03ac07e36d7289f70beb77f217c32c992b4c4ed6416259a65c0d3b7c0b3f`. Its immutable source revision is not established by the cached artifact; that remains a qualification gap.

The recorded compiler failure is local evidence, not a diagnosis of every existing TeamCity failure. Integrate the reviewed feature layers and rerun the coordinated build with recorded source revisions and artifact hashes before promotion.

</details>
